### PR TITLE
Feature/cms integration

### DIFF
--- a/.github/workflows/cms-sync.yml
+++ b/.github/workflows/cms-sync.yml
@@ -16,14 +16,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+<<<<<<< HEAD
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
 
+=======
+>>>>>>> 27ad3db (refactor(cms): update sync workflow to upload config to Vercel Blob)
       - name: Upload config to Vercel Blob
         env:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
         run: |
+<<<<<<< HEAD
           npm install --no-save @vercel/blob
           node -e "
             const { put } = require('@vercel/blob');
@@ -36,3 +40,10 @@ jobs:
             }).then(r => console.log('Uploaded:', r.url))
               .catch(e => { console.error(e.message); process.exit(1); });
           "
+=======
+          curl -sf -X PUT "https://blob.vercel-storage.com/config/site.json" \
+            -H "Authorization: Bearer ${BLOB_READ_WRITE_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "x-content-type: application/json" \
+            --data-binary @cms.config.json
+>>>>>>> 27ad3db (refactor(cms): update sync workflow to upload config to Vercel Blob)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*.public.blob.vercel-storage.com',
+      },
+    ],
+  },
+};
+
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@vercel/blob": "^0.27.0",
         "date-fns": "^4.1.0",
         "eslint-config-next": "^15.4.8",
         "gray-matter": "^4.0.3",
@@ -191,6 +192,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1565,6 +1575,22 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-0.27.3.tgz",
+      "integrity": "sha512-WizeAxzOTmv0JL7wOaxvLIU/KdBcrclM1ZUOdSlIZAxsTTTe1jsyBthStLby0Ueh7FnmKYAjLz26qRJTk5SDkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1802,6 +1828,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -3499,6 +3534,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -3655,6 +3713,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -5250,6 +5314,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5799,6 +5872,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -6022,6 +6107,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@vercel/blob": "^0.27.0",
     "date-fns": "^4.1.0",
     "eslint-config-next": "^15.4.8",
     "gray-matter": "^4.0.3",

--- a/src/components/date.tsx
+++ b/src/components/date.tsx
@@ -1,6 +1,8 @@
-import { parseISO, format } from 'date-fns';
+import { parseISO, format, isValid } from 'date-fns';
 
 export default function Date({ dateString }: { dateString: string }) {
+    if (!dateString) return <time dateTime="">—</time>;
     const date = parseISO(dateString);
+    if (!isValid(date)) return <time dateTime={dateString}>{dateString}</time>;
     return <time dateTime={dateString}>{format(date, 'LLLL d, yyyy')}</time>;
 }

--- a/src/lib/adapters/bundle/contract.ts
+++ b/src/lib/adapters/bundle/contract.ts
@@ -1,0 +1,8 @@
+import type { CmsSiteBundle } from '../../cms';
+
+export interface BundleAdapter {
+  /**
+   * Fetch the current site bundle. Throws if unavailable.
+   */
+  fetchBundle(): Promise<CmsSiteBundle>;
+}

--- a/src/lib/adapters/bundle/http.ts
+++ b/src/lib/adapters/bundle/http.ts
@@ -1,0 +1,33 @@
+import type { BundleAdapter } from './contract';
+import type { CmsSiteBundle } from '../../cms';
+
+/**
+ * Fetches the site bundle over HTTP with an optional Bearer token.
+ * Use for local dev (CMS running at BUNDLE_URL) or any HTTP endpoint.
+ *
+ * Required env vars:
+ *   BUNDLE_URL    - the CMS /api/export endpoint
+ *   BUNDLE_SECRET - bearer token (optional; required if CMS has auth enabled)
+ */
+export function createHttpBundleAdapter(): BundleAdapter {
+  return {
+    async fetchBundle(): Promise<CmsSiteBundle> {
+      const url = process.env.BUNDLE_URL;
+      if (!url) {
+        throw new Error(
+          'BUNDLE_URL is not set. ' +
+          'Set it to the CMS export endpoint (e.g. http://localhost:3000/api/export).'
+        );
+      }
+
+      const secret = process.env.BUNDLE_SECRET;
+      const headers: HeadersInit = secret ? { Authorization: `Bearer ${secret}` } : {};
+
+      const res = await fetch(url, { cache: 'no-store', headers });
+      if (!res.ok) {
+        throw new Error(`Bundle fetch failed: ${res.status} ${res.statusText}`);
+      }
+      return res.json() as Promise<CmsSiteBundle>;
+    },
+  };
+}

--- a/src/lib/adapters/bundle/index.ts
+++ b/src/lib/adapters/bundle/index.ts
@@ -1,0 +1,27 @@
+import type { BundleAdapter } from './contract';
+import { createHttpBundleAdapter } from './http';
+import { createVercelBundleAdapter } from './vercel';
+
+export type { BundleAdapter };
+
+/**
+ * Returns the appropriate bundle adapter based on BUNDLE_PROVIDER env var.
+ *
+ *   BUNDLE_PROVIDER=vercel  → VercelBundleAdapter (private blob via SDK)
+ *   BUNDLE_PROVIDER=http    → HttpBundleAdapter (Bearer-authed HTTP fetch)
+ *   (unset)                 → HttpBundleAdapter (default; works for local dev)
+ */
+export function getBundleAdapter(): BundleAdapter {
+  const provider = process.env.BUNDLE_PROVIDER ?? 'http';
+
+  switch (provider) {
+    case 'vercel':
+      return createVercelBundleAdapter();
+    case 'http':
+      return createHttpBundleAdapter();
+    default:
+      throw new Error(
+        `Unknown BUNDLE_PROVIDER "${provider}". Supported values: "vercel", "http".`
+      );
+  }
+}

--- a/src/lib/adapters/bundle/vercel.ts
+++ b/src/lib/adapters/bundle/vercel.ts
@@ -1,0 +1,34 @@
+import type { BundleAdapter } from './contract';
+import type { CmsSiteBundle } from '../../cms';
+
+/**
+ * Fetches the site bundle from a private Vercel Blob store using the SDK.
+ * The SDK handles authentication via BLOB_READ_WRITE_TOKEN automatically.
+ *
+ * Required env vars:
+ *   BLOB_READ_WRITE_TOKEN - auto-injected by Vercel when a blob store is linked
+ *   BUNDLE_BLOB_KEY       - pathname of the bundle in the blob store
+ *                           (e.g. "export/site-bundle.json")
+ */
+export function createVercelBundleAdapter(): BundleAdapter {
+  return {
+    async fetchBundle(): Promise<CmsSiteBundle> {
+      const key = process.env.BUNDLE_BLOB_KEY;
+      if (!key) {
+        throw new Error('BUNDLE_BLOB_KEY is not set (e.g. "export/site-bundle.json").');
+      }
+
+      // Lazy import so the module is only loaded when this adapter is used
+      const { head } = await import('@vercel/blob');
+
+      // head() authenticates via BLOB_READ_WRITE_TOKEN and returns a signed downloadUrl
+      const meta = await head(key);
+
+      const res = await fetch(meta.downloadUrl, { cache: 'no-store' });
+      if (!res.ok) {
+        throw new Error(`Bundle download failed: ${res.status} ${res.statusText}`);
+      }
+      return res.json() as Promise<CmsSiteBundle>;
+    },
+  };
+}

--- a/src/lib/cms.ts
+++ b/src/lib/cms.ts
@@ -1,6 +1,3 @@
-import { list } from '@vercel/blob';
-import cmsConfig from '../../cms.config.json';
-
 // Lean bundle types — only what the site needs
 export interface CmsBundleAsset {
   fieldName: string;
@@ -27,53 +24,23 @@ export interface CmsSiteBundle {
   collections: Record<string, CmsBundleCollection>;
 }
 
-type CmsConfigShape = {
-  storage?: { provider: string; bundleKey: string };
-};
-
 async function fetchBundle(): Promise<CmsSiteBundle> {
-  const bundleUrl = process.env.CMS_BUNDLE_URL;
-  if (bundleUrl) {
-    const res = await fetch(bundleUrl, { cache: 'no-store' });
-    if (!res.ok) {
-      throw new Error(`CMS bundle fetch failed: ${res.status} ${res.statusText}`);
-    }
-    return res.json() as Promise<CmsSiteBundle>;
-  }
-
-  const storageConfig = (cmsConfig as CmsConfigShape).storage;
-  if (!storageConfig) {
+  const url = process.env.BUNDLE_URL;
+  if (!url) {
     throw new Error(
-      'CMS_BUNDLE_URL is not set and cms.config.json has no storage block. ' +
-      'Set CMS_BUNDLE_URL to the local CMS export endpoint (e.g. http://localhost:3000/api/export).'
+      'BUNDLE_URL is not set. ' +
+      'Set it to the CMS export endpoint (e.g. http://localhost:3000/api/export).'
     );
   }
 
-  if (storageConfig.provider === 'vercel') {
-    const token = process.env.BLOB_READ_WRITE_TOKEN;
-    if (!token) throw new Error('BLOB_READ_WRITE_TOKEN is not set');
+  const secret = process.env.BUNDLE_SECRET;
+  const headers: HeadersInit = secret ? { Authorization: `Bearer ${secret}` } : {};
 
-    const { blobs } = await list({ prefix: storageConfig.bundleKey, token });
-    const entry = blobs.find(b => b.pathname === storageConfig.bundleKey);
-    if (!entry) {
-      throw new Error(
-        `Site bundle not found in Vercel Blob at "${storageConfig.bundleKey}". ` +
-        'Has the CMS published the site at least once?'
-      );
-    }
-
-    // downloadUrl is a pre-authenticated URL returned by the Vercel Blob SDK
-    const res = await fetch(entry.downloadUrl);
-    if (!res.ok) {
-      throw new Error(`Bundle download failed: ${res.status} ${res.statusText}`);
-    }
-    return res.json() as Promise<CmsSiteBundle>;
+  const res = await fetch(url, { cache: 'no-store', headers });
+  if (!res.ok) {
+    throw new Error(`Bundle fetch failed: ${res.status} ${res.statusText}`);
   }
-
-  throw new Error(
-    `Storage provider "${storageConfig.provider}" is not supported by cms.ts. ` +
-    'Only "vercel" is currently implemented.'
-  );
+  return res.json() as Promise<CmsSiteBundle>;
 }
 
 // Module-level singleton — bundle is fetched once per build process
@@ -84,8 +51,10 @@ let _fetched = false;
  * Returns the site bundle from the CMS, or null if unavailable.
  * Falls back gracefully so callers can use local markdown data instead.
  *
- * Local dev: set CMS_BUNDLE_URL=http://localhost:3000/api/export
- * Production: set BLOB_READ_WRITE_TOKEN; bundle key is read from cms.config.json
+ * Set BUNDLE_URL to the export endpoint:
+ *   Local dev:  http://localhost:3000/api/export
+ *   Vercel:     the public Vercel Blob URL written by the CMS at publish time
+ * Set BUNDLE_SECRET if the endpoint requires Bearer auth (local CMS).
  */
 export async function getSiteBundle(): Promise<CmsSiteBundle | null> {
   if (_fetched) return _bundle;

--- a/src/lib/cms.ts
+++ b/src/lib/cms.ts
@@ -1,3 +1,5 @@
+import { getBundleAdapter } from './adapters/bundle';
+
 // Lean bundle types — only what the site needs
 export interface CmsBundleAsset {
   fieldName: string;
@@ -24,43 +26,23 @@ export interface CmsSiteBundle {
   collections: Record<string, CmsBundleCollection>;
 }
 
-async function fetchBundle(): Promise<CmsSiteBundle> {
-  const url = process.env.BUNDLE_URL;
-  if (!url) {
-    throw new Error(
-      'BUNDLE_URL is not set. ' +
-      'Set it to the CMS export endpoint (e.g. http://localhost:3000/api/export).'
-    );
-  }
-
-  const secret = process.env.BUNDLE_SECRET;
-  const headers: HeadersInit = secret ? { Authorization: `Bearer ${secret}` } : {};
-
-  const res = await fetch(url, { cache: 'no-store', headers });
-  if (!res.ok) {
-    throw new Error(`Bundle fetch failed: ${res.status} ${res.statusText}`);
-  }
-  return res.json() as Promise<CmsSiteBundle>;
-}
-
 // Module-level singleton — bundle is fetched once per build process
 let _bundle: CmsSiteBundle | null = null;
 let _fetched = false;
 
 /**
- * Returns the site bundle from the CMS, or null if unavailable.
+ * Returns the site bundle, or null if unavailable.
  * Falls back gracefully so callers can use local markdown data instead.
  *
- * Set BUNDLE_URL to the export endpoint:
- *   Local dev:  http://localhost:3000/api/export
- *   Vercel:     the public Vercel Blob URL written by the CMS at publish time
- * Set BUNDLE_SECRET if the endpoint requires Bearer auth (local CMS).
+ * Adapter is selected by BUNDLE_PROVIDER env var:
+ *   http (default) — fetch(BUNDLE_URL) with optional Bearer BUNDLE_SECRET
+ *   vercel         — @vercel/blob head(BUNDLE_BLOB_KEY) → signed downloadUrl
  */
 export async function getSiteBundle(): Promise<CmsSiteBundle | null> {
   if (_fetched) return _bundle;
   _fetched = true;
   try {
-    _bundle = await fetchBundle();
+    _bundle = await getBundleAdapter().fetchBundle();
   } catch (err) {
     console.warn(
       '[cms] Bundle unavailable, falling back to local data:',

--- a/src/lib/cms.ts
+++ b/src/lib/cms.ts
@@ -1,0 +1,102 @@
+import { list } from '@vercel/blob';
+import cmsConfig from '../../cms.config.json';
+
+// Lean bundle types — only what the site needs
+export interface CmsBundleAsset {
+  fieldName: string;
+  key: string;
+  url: string | null;
+}
+
+export interface CmsBundleCollectionItem {
+  id: string;
+  versionId: string;
+  updatedAt: string;
+  content: Record<string, unknown>;
+  assets: CmsBundleAsset[];
+}
+
+export interface CmsBundleCollection {
+  name: string;
+  items: CmsBundleCollectionItem[];
+}
+
+export interface CmsSiteBundle {
+  contractVersion: string;
+  generatedAt: string;
+  collections: Record<string, CmsBundleCollection>;
+}
+
+type CmsConfigShape = {
+  storage?: { provider: string; bundleKey: string };
+};
+
+async function fetchBundle(): Promise<CmsSiteBundle> {
+  const bundleUrl = process.env.CMS_BUNDLE_URL;
+  if (bundleUrl) {
+    const res = await fetch(bundleUrl, { cache: 'no-store' });
+    if (!res.ok) {
+      throw new Error(`CMS bundle fetch failed: ${res.status} ${res.statusText}`);
+    }
+    return res.json() as Promise<CmsSiteBundle>;
+  }
+
+  const storageConfig = (cmsConfig as CmsConfigShape).storage;
+  if (!storageConfig) {
+    throw new Error(
+      'CMS_BUNDLE_URL is not set and cms.config.json has no storage block. ' +
+      'Set CMS_BUNDLE_URL to the local CMS export endpoint (e.g. http://localhost:3000/api/export).'
+    );
+  }
+
+  if (storageConfig.provider === 'vercel') {
+    const token = process.env.BLOB_READ_WRITE_TOKEN;
+    if (!token) throw new Error('BLOB_READ_WRITE_TOKEN is not set');
+
+    const { blobs } = await list({ prefix: storageConfig.bundleKey, token });
+    const entry = blobs.find(b => b.pathname === storageConfig.bundleKey);
+    if (!entry) {
+      throw new Error(
+        `Site bundle not found in Vercel Blob at "${storageConfig.bundleKey}". ` +
+        'Has the CMS published the site at least once?'
+      );
+    }
+
+    // downloadUrl is a pre-authenticated URL returned by the Vercel Blob SDK
+    const res = await fetch(entry.downloadUrl);
+    if (!res.ok) {
+      throw new Error(`Bundle download failed: ${res.status} ${res.statusText}`);
+    }
+    return res.json() as Promise<CmsSiteBundle>;
+  }
+
+  throw new Error(
+    `Storage provider "${storageConfig.provider}" is not supported by cms.ts. ` +
+    'Only "vercel" is currently implemented.'
+  );
+}
+
+// Module-level singleton — bundle is fetched once per build process
+let _bundle: CmsSiteBundle | null = null;
+let _fetched = false;
+
+/**
+ * Returns the site bundle from the CMS, or null if unavailable.
+ * Falls back gracefully so callers can use local markdown data instead.
+ *
+ * Local dev: set CMS_BUNDLE_URL=http://localhost:3000/api/export
+ * Production: set BLOB_READ_WRITE_TOKEN; bundle key is read from cms.config.json
+ */
+export async function getSiteBundle(): Promise<CmsSiteBundle | null> {
+  if (_fetched) return _bundle;
+  _fetched = true;
+  try {
+    _bundle = await fetchBundle();
+  } catch (err) {
+    console.warn(
+      '[cms] Bundle unavailable, falling back to local data:',
+      err instanceof Error ? err.message : err
+    );
+  }
+  return _bundle;
+}

--- a/src/lib/photos.ts
+++ b/src/lib/photos.ts
@@ -23,8 +23,8 @@ export async function getSortedPhotosData(): Promise<Photo[]> {
   if (cmsItems && cmsItems.length > 0) {
     return cmsItems
       .map(item => {
-        const width = Number(item.content.width ?? 1);
-        const height = Number(item.content.height ?? 1);
+        const width = Math.max(1, Number(item.content.width) || 1);
+        const height = Math.max(1, Number(item.content.height) || 1);
         const imageAsset = item.assets.find(a => a.fieldName === 'image');
         return {
           id: item.id,
@@ -78,8 +78,8 @@ export async function getPhotoData(id: string): Promise<Photo> {
   const cmsItem = bundle?.collections?.photos?.items?.find(i => i.id === id);
 
   if (cmsItem) {
-    const width = Number(cmsItem.content.width ?? 1);
-    const height = Number(cmsItem.content.height ?? 1);
+    const width = Math.max(1, Number(cmsItem.content.width) || 1);
+    const height = Math.max(1, Number(cmsItem.content.height) || 1);
     const imageAsset = cmsItem.assets.find(a => a.fieldName === 'image');
     return {
       id,

--- a/src/lib/photos.ts
+++ b/src/lib/photos.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
-import { remark } from 'remark';
-import html from 'remark-html';
+import { getSiteBundle } from './cms';
 
 export interface Photo {
   id: string;
-  filename: string;
+  filename?: string;
+  url?: string;
   date_taken: string;
   description: string;
   width: number;
@@ -16,80 +16,93 @@ export interface Photo {
 
 const photosDirectory = path.join(process.cwd(), 'src/data/photos');
 
-export function getSortedPhotosData(): Photo[] {
-  const imageMetadataFilenames = fs.readdirSync(photosDirectory);
-  const allPhotosData = imageMetadataFilenames.map((imageMetadataFilename) => {
-    const id = imageMetadataFilename.replace(/\.md$/, '');
-  
-    const fullPath = path.join(photosDirectory, imageMetadataFilename);
-    const fileContents = fs.readFileSync(fullPath, 'utf8');
-  
-    const matterResult = matter(fileContents);
-    const imageMetadata = matterResult.data;
+export async function getSortedPhotosData(): Promise<Photo[]> {
+  const bundle = await getSiteBundle();
+  const cmsItems = bundle?.collections?.photos?.items;
 
-    const width = imageMetadata.width;
-    const height = imageMetadata.height;
-    const aspectRatio = width / height;
+  if (cmsItems && cmsItems.length > 0) {
+    return cmsItems
+      .map(item => {
+        const width = Number(item.content.width ?? 1);
+        const height = Number(item.content.height ?? 1);
+        const imageAsset = item.assets.find(a => a.fieldName === 'image');
+        return {
+          id: item.id,
+          url: imageAsset?.url ?? undefined,
+          date_taken: String(item.content.date_taken ?? ''),
+          description: String(item.content.description ?? ''),
+          width,
+          height,
+          aspectRatio: width / height,
+        };
+      })
+      .sort((a, b) => (a.date_taken > b.date_taken ? -1 : 1));
+  }
 
-    const filename = imageMetadata.filename;
-    const date_taken = imageMetadata.date_taken;
-    const description = imageMetadata.description;
-  
+  // Markdown fallback
+  return fs.readdirSync(photosDirectory)
+    .map(filename => {
+      const id = filename.replace(/\.md$/, '');
+      const { data } = matter(fs.readFileSync(path.join(photosDirectory, filename), 'utf8'));
+      const width = data.width;
+      const height = data.height;
+      return {
+        id,
+        filename: data.filename as string,
+        date_taken: data.date_taken as string,
+        description: data.description as string,
+        width,
+        height,
+        aspectRatio: width / height,
+      };
+    })
+    .sort((a, b) => (a.date_taken > b.date_taken ? -1 : 1));
+}
+
+export async function getAllPhotoIds(): Promise<Array<{ params: { id: string } }>> {
+  const bundle = await getSiteBundle();
+  const cmsItems = bundle?.collections?.photos?.items;
+
+  if (cmsItems && cmsItems.length > 0) {
+    return cmsItems.map(item => ({ params: { id: item.id } }));
+  }
+
+  // Markdown fallback
+  return fs.readdirSync(photosDirectory).map(filename => ({
+    params: { id: filename.replace(/\.md$/, '') },
+  }));
+}
+
+export async function getPhotoData(id: string): Promise<Photo> {
+  const bundle = await getSiteBundle();
+  const cmsItem = bundle?.collections?.photos?.items?.find(i => i.id === id);
+
+  if (cmsItem) {
+    const width = Number(cmsItem.content.width ?? 1);
+    const height = Number(cmsItem.content.height ?? 1);
+    const imageAsset = cmsItem.assets.find(a => a.fieldName === 'image');
     return {
       id,
-      filename,
-      date_taken,
-      aspectRatio,
+      url: imageAsset?.url ?? undefined,
+      date_taken: String(cmsItem.content.date_taken ?? ''),
+      description: String(cmsItem.content.description ?? ''),
       width,
       height,
-      description
+      aspectRatio: width / height,
     };
-  });
+  }
 
-  return allPhotosData.sort((a, b) => {
-    if (a && b && a.date_taken > b.date_taken) {
-      return -1;
-    } else {
-      return 1;
-    }
-  });
-}
-
-export function getAllPhotoIds() {
-  const fileNames = fs.readdirSync(photosDirectory);
-  
-  return fileNames.map((filename) => {
-    return {
-      params: {
-        id: filename.replace(/\.md$/, ''),
-      },
-    };
-  });
-}
-
-export function getPhotoData(id: string): Photo {
-  const imageMetadataFilename = `${id}.md`;
-  const fullPath = path.join(photosDirectory, imageMetadataFilename);
-  const fileContents = fs.readFileSync(fullPath, 'utf8');
-  
-  const matterResult = matter(fileContents);
-  const imageMetadata = matterResult.data;
-
-  const width = imageMetadata.width;
-  const height = imageMetadata.height;
-  const aspectRatio = width / height;
-
-  const filename = imageMetadata.filename;
-  const date_taken = imageMetadata.date_taken;
-  const description = imageMetadata.description;
-  
+  // Markdown fallback
+  const { data } = matter(fs.readFileSync(path.join(photosDirectory, `${id}.md`), 'utf8'));
+  const width = data.width;
+  const height = data.height;
   return {
     id,
-    filename,
-    date_taken,
-    aspectRatio,
+    filename: data.filename as string,
+    date_taken: data.date_taken as string,
+    description: data.description as string,
     width,
     height,
-    description
+    aspectRatio: width / height,
   };
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -3,77 +3,88 @@ import path from 'path';
 import matter from 'gray-matter';
 import { remark } from 'remark';
 import html from 'remark-html';
+import { getSiteBundle } from './cms';
 
 export interface Post {
-
+  id: string;
+  title: string;
+  createdAt: string;
 }
 
 const postsDirectory = path.join(process.cwd(), 'src/data/posts');
 
-export function getSortedPostsData() {
-  const fileNames = fs.readdirSync(postsDirectory);
-  const allPostsData = fileNames.map((filename) => {
-    const id = filename.replace(/\.md$/, '');
-  
-    const fullPath = path.join(postsDirectory, filename);
-    const fileContents = fs.readFileSync(fullPath, 'utf8');
-  
-    const matterResult = matter(fileContents);
-    
-    let article = undefined;
-    const isPublished = matterResult.data['Published'];
-    const createdAt = matterResult.data['CreatedAt'];
-    const title = matterResult.data['Title'];
+export async function getSortedPostsData(): Promise<Post[]> {
+  const bundle = await getSiteBundle();
+  const cmsItems = bundle?.collections?.posts?.items;
 
-    if (isPublished) {
-      article = {
+  if (cmsItems && cmsItems.length > 0) {
+    return cmsItems
+      .filter(item => item.content.published === true)
+      .map(item => ({
+        id: item.id,
+        title: String(item.content.title ?? ''),
+        createdAt: String(item.content.createdAt ?? ''),
+      }))
+      .sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1));
+  }
+
+  // Markdown fallback
+  return fs.readdirSync(postsDirectory)
+    .map(filename => {
+      const id = filename.replace(/\.md$/, '');
+      const fullPath = path.join(postsDirectory, filename);
+      const { data } = matter(fs.readFileSync(fullPath, 'utf8'));
+      if (!data['Published']) return undefined;
+      return {
         id,
-        createdAt,
-        title,
+        title: String(data['Title'] ?? ''),
+        createdAt: String(data['CreatedAt'] ?? ''),
       };
-    }    
-
-    return article;
-  })
-  .filter(
-    (article => article !== undefined)
-  );
-
-  return allPostsData.sort((a, b) => {
-    if (a && b && a.createdAt > b.createdAt) {
-      return 1;
-    } else {
-      return -1;
-    }
-  });
+    })
+    .filter((p): p is Post => p !== undefined)
+    .sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1));
 }
 
-export function getAllPostIds() {
-  const fileNames = fs.readdirSync(postsDirectory);
-  
-  return fileNames.map((filename) => {
-    return {
-      params: {
-        id: filename.replace(/\.md$/, ''),
-      },
-    };
-  });
+export async function getAllPostIds(): Promise<Array<{ params: { id: string } }>> {
+  const bundle = await getSiteBundle();
+  const cmsItems = bundle?.collections?.posts?.items;
+
+  if (cmsItems && cmsItems.length > 0) {
+    return cmsItems.map(item => ({ params: { id: item.id } }));
+  }
+
+  // Markdown fallback
+  return fs.readdirSync(postsDirectory).map(filename => ({
+    params: { id: filename.replace(/\.md$/, '') },
+  }));
 }
 
 export async function getPostData(id: string) {
+  const bundle = await getSiteBundle();
+  const cmsItem = bundle?.collections?.posts?.items?.find(i => i.id === id);
+
+  if (cmsItem) {
+    const processedContent = await remark()
+      .use(html)
+      .process(String(cmsItem.content.body ?? ''));
+    return {
+      id,
+      title: String(cmsItem.content.title ?? ''),
+      createdAt: String(cmsItem.content.createdAt ?? ''),
+      content: processedContent.toString(),
+    };
+  }
+
+  // Markdown fallback
   const fullPath = path.join(postsDirectory, `${id}.md`);
-  const fileContents = fs.readFileSync(fullPath, 'utf8');
-  
-  const matterResult = matter(fileContents);
-  
+  const matterResult = matter(fs.readFileSync(fullPath, 'utf8'));
   const processedContent = await remark()
     .use(html)
     .process(matterResult.content);
-  const content = processedContent.toString();
-  
   return {
     id,
-    content,
-    ...matterResult.data,
+    title: String(matterResult.data['Title'] ?? ''),
+    createdAt: String(matterResult.data['CreatedAt'] ?? ''),
+    content: processedContent.toString(),
   };
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -50,7 +50,9 @@ export async function getAllPostIds(): Promise<Array<{ params: { id: string } }>
   const cmsItems = bundle?.collections?.posts?.items;
 
   if (cmsItems && cmsItems.length > 0) {
-    return cmsItems.map(item => ({ params: { id: item.id } }));
+    return cmsItems
+      .filter(item => item.content.published === true)
+      .map(item => ({ params: { id: item.id } }));
   }
 
   // Markdown fallback

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -5,7 +5,7 @@ import Avatar from '../components/avatar';
 import { Photo, getPhotoData } from '../lib/photos';
 
 export const getStaticProps: GetStaticProps = async () => {
-  const profilePhoto = getPhotoData('me');
+  const profilePhoto = await getPhotoData('me');
   return {
     props: {
       profilePhoto,

--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -24,15 +24,13 @@ export default function Code({ repos }: { repos: { name: string, desc: string, u
         {repos.map(({ name, desc, url, createdAt, updatedAt, languages }) => (
           <li key={name}>
             <div>
-              <a href={url} target="_blank" rel="noopener noreferrer">
-                <div key={name} className="repocard">
-                  <a href={url} target="_blank" rel="noopener noreferrer" className="repolink"></a>
-                  <p className="name">{name}</p>
-                  <p className="created-at">Created <Date dateString={createdAt} /></p>
-                  <p className="description">{desc}</p>
-                  {/*<p className="languages">Built with: {languages}</p>*/}
-                </div>
-              </a>
+              <div key={name} className="repocard">
+                <a href={url} target="_blank" rel="noopener noreferrer" className="repolink"></a>
+                <p className="name">{name}</p>
+                <p className="created-at">Created <Date dateString={createdAt} /></p>
+                <p className="description">{desc}</p>
+                {/*<p className="languages">Built with: {languages}</p>*/}
+              </div>
             </div>
           </li>
         ))}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,8 +8,8 @@ import { getSortedPhotosData } from '../lib/photos';
 import { getSortedRepoData } from '../lib/github';
 
 export const getStaticProps: GetStaticProps = async () => {
-  const allPostsData = getSortedPostsData();
-  const allPhotosData = getSortedPhotosData();
+  const allPostsData = await getSortedPostsData();
+  const allPhotosData = await getSortedPhotosData();
   //const allRepoData = getSortedRepoData();
 
   const allData: any = [];

--- a/src/pages/photos.tsx
+++ b/src/pages/photos.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 
 export const getStaticProps: GetStaticProps = async () => {
-  const allPhotosData = getSortedPhotosData();
+  const allPhotosData = await getSortedPhotosData();
   return {
     props: {
       allPhotosData,
@@ -28,7 +28,7 @@ export default function Photos({ allPhotosData }: { allPhotosData: Photo[] }) {
                 <div>
                   <Link href={`/photos/${photo.id}`}>
                     <Image
-                      src={`/images/${photo.filename}`}
+                      src={photo.url ?? `/images/${photo.filename}`}
                       alt={photo.description}
                       width={(photo.aspectRatio > 1) ? thumbnailSize * photo.aspectRatio : thumbnailSize}
                       height={(photo.aspectRatio < 1) ? thumbnailSize / photo.aspectRatio : thumbnailSize}

--- a/src/pages/photos/[id].tsx
+++ b/src/pages/photos/[id].tsx
@@ -31,7 +31,7 @@ export default function PhotoPage({ photo }: { photo: Photo }) {
     <Layout pageName={pageName} pageId={`photo-${pageName}`}>
       <article>
         <div>
-          <Image 
+          <Image
             src={photo.url ?? `/images/${photo.filename}`}
             alt={photo.description}
             width={(photo.aspectRatio > 1) ? imageSize * photo.aspectRatio : imageSize}

--- a/src/pages/photos/[id].tsx
+++ b/src/pages/photos/[id].tsx
@@ -16,7 +16,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = getAllPhotoIds();
+  const paths = await getAllPhotoIds();
   return {
     paths,
     fallback: false,
@@ -32,7 +32,7 @@ export default function PhotoPage({ photo }: { photo: Photo }) {
       <article>
         <div>
           <Image 
-            src={`/images/${photo.filename}`}
+            src={photo.url ?? `/images/${photo.filename}`}
             alt={photo.description}
             width={(photo.aspectRatio > 1) ? imageSize * photo.aspectRatio : imageSize}
             height={(photo.aspectRatio < 1) ? imageSize / photo.aspectRatio : imageSize}

--- a/src/pages/posts.tsx
+++ b/src/pages/posts.tsx
@@ -6,7 +6,7 @@ import Date from '../components/date';
 import { getSortedPostsData } from '../lib/posts';
 
 export const getStaticProps: GetStaticProps = async () => {
-  const allPostsData = getSortedPostsData();
+  const allPostsData = await getSortedPostsData();
   return {
     props: {
       allPostsData,

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -14,7 +14,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = getAllPostIds();
+  const paths = await getAllPostIds();
   return {
     paths,
     fallback: false,
@@ -22,12 +22,12 @@ export const getStaticPaths: GetStaticPaths = async () => {
 }
 
 export default function Post({ postData }: any) {
-  const pageName = postData.Title;
+  const pageName = postData.title;
   return (
     <Layout pageName={pageName}>
       <article>
         <div className="">
-          <Date dateString={postData.CreatedAt} />
+          <Date dateString={postData.createdAt} />
         </div>
         <div dangerouslySetInnerHTML={{ __html: postData.content}} />
       </article>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "target": "ES2017",
     "plugins": [
       {


### PR DESCRIPTION
This pull request introduces a new CMS integration that enables the site to fetch content (posts and photos) from a remote bundle, with support for both HTTP and Vercel Blob backends. The codebase now prefers CMS data when available, falling back to local markdown files if not. Several new adapters and types are introduced to support this, and the data-fetching logic in `posts` and `photos` is refactored to be asynchronous and CMS-aware. Additionally, a GitHub Actions workflow is added for syncing the CMS config to Vercel Blob.

**CMS Integration and Data Fetching Refactor:**

* Added a new CMS bundle contract (`CmsSiteBundle` and related types) in `src/lib/cms.ts`, and implemented a singleton `getSiteBundle()` function to fetch and cache the bundle, preferring CMS data and falling back to markdown if unavailable.
* Introduced a bundle adapter pattern in `src/lib/adapters/bundle/` with HTTP and Vercel Blob implementations, selected via the `BUNDLE_PROVIDER` environment variable. [[1]](diffhunk://#diff-94e46a3d024f6da310d8af2c4e74a18f8df3bfb96a455b5e102edb0801626769R1-R8) [[2]](diffhunk://#diff-9aed5110632ca3a3c48c9f58e929ccaf7c8092b10eb755312d75bb44e1f69741R1-R33) [[3]](diffhunk://#diff-24a8df1cd753f2f104f96000110e78c13958b970b97f7ec25f82d161d656d782R1-R34) [[4]](diffhunk://#diff-722350a24776e0464c793e9152d2226709ade85e4b8a05c924b7b72bc5029d55R1-R27)
* Refactored `getSortedPostsData`, `getAllPostIds`, `getPostData` (in `src/lib/posts.ts`), and `getSortedPhotosData`, `getAllPhotoIds`, `getPhotoData` (in `src/lib/photos.ts`) to use CMS data when available, with asynchronous APIs and local markdown fallback. [[1]](diffhunk://#diff-ff65b747fb3e3d7272cf9900e9e7e723d2ef6f6a30b9eb8afca660f9a440cef4R6-R88) [[2]](diffhunk://#diff-a3b8a5dda35b00e2a0449a290c4d82234f0d555419f6e982ffff275785a3a5b3L4-R9) [[3]](diffhunk://#diff-a3b8a5dda35b00e2a0449a290c4d82234f0d555419f6e982ffff275785a3a5b3L19-R106)

**Build and Runtime Changes:**

* Updated all relevant `getStaticProps` and `getStaticPaths` usages in pages to await the new asynchronous data-fetching functions, ensuring CMS content is used at build time. [[1]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987L11-R12) [[2]](diffhunk://#diff-929739f8f18979fa6c73134d3d6d0e778339723192d098164396eba306c31959L8-R8) [src/pages/photos/[id].tsxL19-R19](diffhunk://#diff-13dfe10a5d07b272d0876c45d33db35209384d38bebcb971b156b424cd60813eL19-R19), [[3]](diffhunk://#diff-1b4935bebe367b0862e6fcf6eb17075319efb19620fe9611002eade1443584d2L8-R8)

**Image Handling Improvements:**

* Updated photo and photo detail pages to use the CMS asset URL if available, falling back to the local image path for legacy markdown-based photos. ([src/pages/photos.tsxL31-R31](diffhunk://#diff-929739f8f18979fa6c73134d3d6d0e778339723192d098164396eba306c31959L31-R31), [src/pages/photos/[id].tsxL35-R35](diffhunk://#diff-13dfe10a5d07b272d0876c45d33db35209384d38bebcb971b156b424cd60813eL35-R35))

**CMS Configuration and Workflow:**

* Added a new `cms.config.json` file describing the site schema, collections, and fields for use by the CMS.
* Added a GitHub Actions workflow (`.github/workflows/cms-sync.yml`) to upload the CMS config to Vercel Blob, supporting both manual and (optionally) automatic syncs.
* Added the `@vercel/blob` package as a dependency for Vercel Blob integration.

These changes collectively enable dynamic, CMS-driven content for posts and photos, with robust fallback and deployment support.