### PR TITLE
feat: add CMS configuration and sync workflow for Vercel Blob

### DIFF
--- a/.github/workflows/cms-sync.yml
+++ b/.github/workflows/cms-sync.yml
@@ -1,0 +1,27 @@
+name: Sync CMS config
+
+on:
+  workflow_dispatch:
+  # Uncomment to sync automatically when cms.config.json changes on main:
+  # push:
+  #   branches: [main]
+  #   paths: [cms.config.json]
+
+jobs:
+  sync:
+    name: Upload cms.config.json to Vercel Blob
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Upload config to Vercel Blob
+        env:
+          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+        run: |
+          curl -sf -X PUT "https://blob.vercel-storage.com/config/site.json" \
+            -H "Authorization: Bearer ${BLOB_READ_WRITE_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "x-content-type: application/json" \
+            --data-binary @cms.config.json

--- a/cms.config.json
+++ b/cms.config.json
@@ -1,0 +1,48 @@
+{
+  "name": "micruopp.com",
+  "siteUrl": "https://micruopp.com",
+  "framework": "nextjs",
+  "schemas": ["homepage", "about"],
+  "pages": [
+    { "slug": "/", "schema": "homepage" },
+    {
+      "slug": "/about",
+      "schema": "about",
+      "rendering": {
+        "titleField": "title",
+        "bodyField": "bio",
+        "imageField": "profileImage",
+        "imageAltField": "profileImageAlt"
+      },
+      "fields": [
+        { "name": "title",           "type": "text",     "label": "Title",           "required": false, "defaultValue": "About" },
+        { "name": "bio",             "type": "richtext", "label": "Bio",             "required": true  },
+        { "name": "profileImage",    "type": "image",    "label": "Profile Photo",   "required": false },
+        { "name": "profileImageAlt", "type": "text",     "label": "Photo Alt Text",  "required": false }
+      ]
+    }
+  ],
+  "collections": [
+    {
+      "name": "posts",
+      "slugPattern": "/posts/{id}",
+      "fields": [
+        { "name": "title",     "type": "text",     "label": "Title",      "required": true  },
+        { "name": "body",      "type": "richtext",  "label": "Body",       "required": true  },
+        { "name": "createdAt", "type": "date",      "label": "Created At", "required": true  },
+        { "name": "published", "type": "boolean",   "label": "Published",  "required": false }
+      ]
+    },
+    {
+      "name": "photos",
+      "slugPattern": "/photos/{id}",
+      "fields": [
+        { "name": "image",       "type": "image",  "label": "Photo",       "required": true  },
+        { "name": "description", "type": "text",   "label": "Description", "required": true  },
+        { "name": "date_taken",  "type": "date",   "label": "Date Taken",  "required": false },
+        { "name": "width",       "type": "number", "label": "Width",       "required": false },
+        { "name": "height",      "type": "number", "label": "Height",      "required": false }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces a new CMS configuration for the site and adds a GitHub Actions workflow to automate syncing this configuration with Vercel Blob storage. The changes primarily focus on enabling structured content management and establishing a workflow for keeping the deployed configuration up to date.

**CMS configuration setup:**

* Added a new `cms.config.json` file that defines site metadata, schemas for pages (`homepage`, `about`), and collections for `posts` and `photos`, including detailed field definitions for each type of content.

**Automation workflow:**

* Added a `.github/workflows/cms-sync.yml` GitHub Actions workflow that uploads the `cms.config.json` to Vercel Blob storage, allowing for easy deployment of CMS configuration changes. The workflow can be triggered manually and is set up for potential future automation on config changes.