### PR TITLE
Feature/cms sync

### DIFF
--- a/.github/workflows/cms-sync.yml
+++ b/.github/workflows/cms-sync.yml
@@ -24,4 +24,5 @@ jobs:
             -H "Authorization: Bearer ${BLOB_READ_WRITE_TOKEN}" \
             -H "Content-Type: application/json" \
             -H "x-content-type: application/json" \
+            -H "x-add-random-suffix: 0" \
             --data-binary @cms.config.json

--- a/.github/workflows/cms-sync.yml
+++ b/.github/workflows/cms-sync.yml
@@ -16,13 +16,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Upload config to Vercel Blob
         env:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
         run: |
-          curl -sf -X PUT "https://blob.vercel-storage.com/config/site.json" \
-            -H "Authorization: Bearer ${BLOB_READ_WRITE_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -H "x-content-type: application/json" \
-            -H "x-add-random-suffix: 0" \
-            --data-binary @cms.config.json
+          npm install --no-save @vercel/blob
+          node -e "
+            const { put } = require('@vercel/blob');
+            const fs = require('fs');
+            put('config/site.json', fs.readFileSync('cms.config.json'), {
+              access: 'public',
+              allowOverwrite: true,
+              contentType: 'application/json',
+              token: process.env.BLOB_READ_WRITE_TOKEN,
+            }).then(r => console.log('Uploaded:', r.url))
+              .catch(e => { console.error(e.message); process.exit(1); });
+          "


### PR DESCRIPTION
This pull request updates the `.github/workflows/cms-sync.yml` workflow to modernize and improve the way the site configuration is uploaded to Vercel Blob. Instead of using a direct `curl` command, the workflow now uses the official `@vercel/blob` Node.js package, which provides better error handling and maintainability.

**Workflow modernization and reliability improvements:**

* Added a step to set up Node.js 20 using `actions/setup-node@v4` to enable running Node scripts in the workflow.
* Replaced the `curl` upload command with a Node.js script that uses the `@vercel/blob` package to upload `cms.config.json` as `config/site.json`, improving error handling and providing clearer output on success or failure.